### PR TITLE
Keep the scheduled workflow alive

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -19,3 +19,6 @@ jobs:
           POCKET_CONSUMER_KEY: ${{ secrets.POCKET_CONSUMER_KEY }}
           POCKET_ACCESS_TOKEN: ${{ secrets.POCKET_ACCESS_TOKEN }}
           PINBOARD_AUTH_TOKEN: ${{ secrets.PINBOARD_AUTH_TOKEN }}
+      - run: gh workflow enable --repo '${{ github.repository }}' '.github/workflows/keepalive.yml'
+        env:
+          GH_TOKEN: ${{ secrets.github_token }}


### PR DESCRIPTION
Even if there's no GitHub repo activity.
